### PR TITLE
Modernized for 2014 Objective-C

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,32 +1,30 @@
-SCEvents
-========
+SCEvents ========
 
-A GCD and ARC Enabled Fork of Stuart Connolly's SCEvents Objective-C wrapper for Mac OS X's FSEvents C API.
+A GCD and ARC Enabled Fork of Stuart Connolly's SCEvents Objective-C wrapper for
+Mac OS X's FSEvents C API. Updated with bug fixes, code cleanup, event flags
+that play nicely with Swift, and inclusion of all FSEvent type flags introduced
+in recent years.
 
-Original code available for download from here: http://stuconnolly.com/downloads/scevents/
+Original code available for download from here:
+http://stuconnolly.com/downloads/scevents/
 
-License
-========
+License ========
 
 Copyright (c) 2011 Stuart Connolly. All rights reserved.
 
-Permission is hereby granted, free of charge, to any person
-obtaining a copy of this software and associated documentation
-files (the "Software"), to deal in the Software without
-restriction, including without limitation the rights to use,
-copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the
-Software is furnished to do so, subject to the following
-conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of
+this software and associated documentation files (the "Software"), to deal in
+the Software without restriction, including without limitation the rights to
+use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+the Software, and to permit persons to whom the Software is furnished to do so,
+subject to the following conditions:
 
-The above copyright notice and this permission notice shall be
-included in all copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND,
-EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES
-OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND
-NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT
-HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY,
-WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
-FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR
-OTHER DEALINGS IN THE SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/SCConstants.h
+++ b/SCConstants.h
@@ -28,16 +28,36 @@
  *  OTHER DEALINGS IN THE SOFTWARE.
  */
 
-typedef enum 
-{ 
-    SCEventStreamEventFlagNone            = 0x00000000, 
-    SCEventStreamEventFlagMustScanSubDirs = 0x00000001, 
-    SCEventStreamEventFlagUserDropped     = 0x00000002, 
-    SCEventStreamEventFlagKernelDropped   = 0x00000004, 
-    SCEventStreamEventFlagEventIdsWrapped = 0x00000008, 
-    SCEventStreamEventFlagHistoryDone     = 0x00000010, 
-    SCEventStreamEventFlagRootChanged     = 0x00000020, 
-    SCEventStreamEventFlagMount           = 0x00000040, 
-    SCEventStreamEventFlagUnmount         = 0x00000080
-} 
-SCEventFlags;
+/* For convenience, we wrap up the event options defined in FSEvents.h into
+ * an option type.
+ */
+typedef NS_OPTIONS(UInt32, SCEventStreamEventFlag) {
+    SCEventStreamEventFlagNone              = 0x00000000,
+    SCEventStreamEventFlagMustScanSubDirs   = 0x00000001,
+    SCEventStreamEventFlagUserDropped       = 0x00000002,
+    SCEventStreamEventFlagKernelDropped     = 0x00000004,
+    SCEventStreamEventFlagEventIdsWrapped   = 0x00000008,
+    SCEventStreamEventFlagHistoryDone       = 0x00000010,
+    SCEventStreamEventFlagRootChanged       = 0x00000020,
+    SCEventStreamEventFlagMount             = 0x00000040,
+    SCEventStreamEventFlagUnmount           = 0x00000080,
+    SCEventStreamEventFlagItemCreated       = 0x00000100,
+    SCEventStreamEventFlagItemRemoved       = 0x00000200,
+    SCEventStreamEventFlagItemInodeMetaMod  = 0x00000400,
+    SCEventStreamEventFlagItemRenamed       = 0x00000800,
+    SCEventStreamEventFlagItemModified      = 0x00001000,
+    SCEventStreamEventFlagItemFinderInfoMod = 0x00002000,
+    SCEventStreamEventFlagItemChangeOwner   = 0x00004000,
+    SCEventStreamEventFlagItemXattrMod      = 0x00008000,
+    SCEventStreamEventFlagItemIsFile        = 0x00010000,
+    SCEventStreamEventFlagItemIsDir         = 0x00020000,
+    SCEventStreamEventFlagItemIsSymlink     = 0x00040000,
+    SCEventStreamEventFlagOwnEvent          = 0x00080000
+};
+
+/* In order to play nicely with Swift, we now let the "real" type name
+ * be a prefix of the option names, which we want to keep basically on par
+ * with the original flag names. However, for backwards compatibility, we
+ * also allow the type name that was used previously.
+ */
+typedef SCEventStreamEventFlag SCEventFlags;

--- a/SCEvent.h
+++ b/SCEvent.h
@@ -35,7 +35,6 @@
 #import <CoreServices/CoreServices.h>
 #endif
 
-
 #import "SCConstants.h"
 
 /**
@@ -46,32 +45,26 @@
  * Class representing a single file system event.
  */
 @interface SCEvent : NSObject 
-{
-    NSUInteger _eventId;
-    NSDate *_eventDate;
-    NSString *_eventPath;
-    SCEventFlags _eventFlags;
-}
 
 /**
- * @property _eventId The ID of the event.
+ * @property eventId The ID of the event.
  */
-@property (readwrite, assign, getter=eventId, setter=setEventId:) NSUInteger _eventId;
+@property (assign) NSUInteger eventId;
 
 /**
- * @property _eventDate The date of the event.
+ * @property eventDate The date of the event.
  */
-@property (readwrite, retain, getter=eventDate, setter=setEventDate:) NSDate *_eventDate;
+@property (strong) NSDate *eventDate;
 
 /**
- * @property _eventPath The file system path of the event.
+ * @property eventPath The file system path of the event.
  */
-@property (readwrite, retain, getter=eventPath, setter=setEventPath:) NSString *_eventPath;
+@property (copy) NSString *eventPath;
 
 /**
- * @property _eventFlag The flags that are associated with the event.
+ * @property eventFlag The flags that are associated with the event.
  */
-@property (readwrite, assign, getter=eventFlags, setter=setEventFlags:) SCEventFlags _eventFlags;
+@property (assign) SCEventFlags eventFlags;
 
 + (SCEvent *)eventWithEventId:(NSUInteger)identifier 
 					eventDate:(NSDate *)date 

--- a/SCEvent.m
+++ b/SCEvent.m
@@ -32,11 +32,6 @@
 
 @implementation SCEvent
 
-@synthesize _eventId;
-@synthesize _eventDate;
-@synthesize _eventPath;
-@synthesize _eventFlags;
-
 #pragma mark -
 #pragma mark Initialisation
 
@@ -100,13 +95,6 @@
 			((unsigned long)_eventId), 
 			[self eventPath], 
 			((unsigned long)_eventFlags)];
-}
-
-#pragma mark -
-
-- (void)dealloc
-{
-    _eventDate = nil;
 }
 
 @end

--- a/SCEvents.h
+++ b/SCEvents.h
@@ -35,7 +35,6 @@
 #import <CoreServices/CoreServices.h>
 #endif
 
-
 #import "SCEventListenerProtocol.h"
 
 @class SCEvent;
@@ -48,62 +47,46 @@
  * An Objective-C wrapper for the FSEvents C API.
  */
 @interface SCEvents : NSObject 
-{
-    __unsafe_unretained id <NSObject, SCEventListenerProtocol> _delegate; 
-    
-    BOOL                 _isWatchingPaths;
-    BOOL                 _ignoreEventsFromSubDirs;
-	CFRunLoopRef         _runLoop;
-    FSEventStreamRef     _eventStream;
-    CFTimeInterval       _notificationLatency;
-	FSEventStreamEventId _resumeFromEventId;
-      
-    SCEvent              *_lastEvent;
-    NSArray              *_watchedPaths;
-    NSArray              *_excludedPaths;
-	
-    dispatch_queue_t     _eventsQueue;
-}
 
 /**
- * @property _delegate The delegate that SCEvents is to notify when events occur
+ * @property delegate The delegate that SCEvents is to notify when events occur
  */
-@property (readwrite, assign, getter=delegate, setter=setDelegate:) id <NSObject, SCEventListenerProtocol> _delegate;
+@property (weak) id <NSObject, SCEventListenerProtocol> delegate;
 
 /**
- * @property _isWatchingPaths Indicates whether the events stream is currently running
+ * @property isWatchingPaths Indicates whether the events stream is currently running
  */
-@property (readonly, getter=isWatchingPaths) BOOL _isWatchingPaths;
+@property (readonly) BOOL isWatchingPaths;
 
 /**
- * @property _ignoreEventsFromSubDirs Indicates whether events from sub-directories of the excluded paths are ignored. Defaults to YES.
+ * @property ignoreEventsFromSubDirs Indicates whether events from sub-directories of the excluded paths are ignored. Defaults to YES.
  */
-@property (readwrite, assign, getter=ignoreEventsFromSubDirs, setter=setIgnoreEventsFromSubDirs:) BOOL _ignoreEventsFromSubDirs;
+@property (assign) BOOL ignoreEventsFromSubDirs;
 
 /**
- * @property _lastEvent The last event that occurred and that was delivered to the delegate.
+ * @property lastEvent The last event that occurred and that was delivered to the delegate.
  */
-@property (readwrite, retain, getter=lastEvent, setter=setLastEvent:) SCEvent *_lastEvent;
+@property (strong) SCEvent *lastEvent;
 
 /**
- * @property _notificationLatency The latency time of which SCEvents is notified by FSEvents of events. Defaults to 3 seconds.
+ * @property notificationLatency The latency time of which SCEvents is notified by FSEvents of events. Defaults to 3 seconds.
  */
-@property (readwrite, assign, getter=notificationLatency, setter=setNotificationLatency:) double _notificationLatency;
+@property (assign) double notificationLatency;
 
 /**
- * @property _watchedPaths The paths that are to be watched for events.
+ * @property watchedPaths The paths that are to be watched for events.
  */
-@property (readwrite, retain, getter=watchedPaths, setter=setWatchedPaths:) NSArray *_watchedPaths;
+@property (copy) NSArray *watchedPaths;
 
 /**
- * @property _excludedPaths The paths that SCEvents should ignore events from and not deliver to the delegate.
+ * @property excludedPaths The paths that SCEvents should ignore events from and not deliver to the delegate.
  */
-@property (readwrite, retain, getter=excludedPaths, setter=setExcludedPaths:) NSArray *_excludedPaths;
+@property (copy) NSArray *excludedPaths;
 
 /**
- * @property _resumeFromEventId The event ID from which to resume from when the stream is started.
+ * @property resumeFromEventId The event ID from which to resume from when the stream is started.
  */
-@property (readwrite, assign, getter=resumeFromEventId, setter=setResumeFromEventId:) FSEventStreamEventId _resumeFromEventId;
+@property (assign) FSEventStreamEventId resumeFromEventId;
 
 - (BOOL)flushEventStreamSync;
 - (BOOL)flushEventStreamAsync;

--- a/SCEvents.m
+++ b/SCEvents.m
@@ -52,21 +52,14 @@ static void _events_callback(ConstFSEventStreamRef streamRef,
 							 void *eventPaths, 
 							 const FSEventStreamEventFlags eventFlags[], 
 							 const FSEventStreamEventId eventIds[]);
-
-static CFStringRef _strip_trailing_slash(CFStringRef string);
-
 @end
 
 @implementation SCEvents
-
-@synthesize _delegate;
-@synthesize _isWatchingPaths;
-@synthesize _ignoreEventsFromSubDirs;
-@synthesize _lastEvent;
-@synthesize _notificationLatency;
-@synthesize _watchedPaths;
-@synthesize _excludedPaths;
-@synthesize _resumeFromEventId;
+{
+	CFRunLoopRef         _runLoop;
+    FSEventStreamRef     _eventStream;
+    dispatch_queue_t     _eventsQueue;
+}
 
 #pragma mark -
 #pragma mark Initialisation
@@ -102,7 +95,6 @@ static CFStringRef _strip_trailing_slash(CFStringRef string);
  */
 - (BOOL)flushEventStreamSync
 {
-    
     if (!_isWatchingPaths) { return NO; }
     
     dispatch_sync(_eventsQueue,
@@ -212,7 +204,7 @@ static CFStringRef _strip_trailing_slash(CFStringRef string);
 	__block NSString *description = nil;
     dispatch_sync(_eventsQueue,
     ^{
-        description = (_isWatchingPaths) ? (__bridge NSString *)FSEventStreamCopyDescription(_eventStream) : nil;
+        description = (_isWatchingPaths) ? (__bridge_transfer NSString *)FSEventStreamCopyDescription(_eventStream) : nil;
     });
 	
 	return description;
@@ -234,31 +226,10 @@ static CFStringRef _strip_trailing_slash(CFStringRef string);
 
 #pragma mark -
 
-- (void)_finalize
-{
-    
-    _delegate = nil;
-	
-	// Stop the event stream if it's still running
-	if (_isWatchingPaths) [self stopWatchingPaths];
-    
-    dispatch_release(_eventsQueue);
-    
-	_lastEvent = nil;
-    _watchedPaths = nil;
-    _excludedPaths = nil;
-    
-}
-
-- (void)finalize
-{
-    [self _finalize];
-    [super finalize];
-}
-
 - (void)dealloc
 {
-    [self _finalize];
+	// Stop the event stream if it's still running
+	if (_isWatchingPaths) [self stopWatchingPaths];
 }
 
 #pragma mark -
@@ -287,7 +258,7 @@ static FSEventStreamRef _create_events_stream(SCEvents *watcher, CFArrayRef path
 							   paths, 
 							   sinceWhen, 
 							   latency, 
-							   kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagWatchRoot);
+							   kFSEventStreamCreateFlagUseCFTypes | kFSEventStreamCreateFlagWatchRoot | kFSEventStreamCreateFlagFileEvents);
 }
 
 /**
@@ -336,10 +307,11 @@ static void _events_callback(ConstFSEventStreamRef streamRef,
          */
         
 		NSArray *excludedPaths = [pathWatcher excludedPaths];
-        CFStringRef eventPath = CFArrayGetValueAtIndex(paths, (CFIndex)i);
+        CFStringRef eventPathCf = CFArrayGetValueAtIndex(paths, (CFIndex)i);
+        NSString *eventPath = (__bridge NSString *)eventPathCf;
         
         // Check to see if the event should be ignored if it's path is in the exclude list
-        if ([excludedPaths containsObject:(__bridge NSString *)eventPath]) {
+        if ([excludedPaths containsObject:eventPath]) {
             shouldIgnore = YES;
         }
         else {
@@ -348,7 +320,7 @@ static void _events_callback(ConstFSEventStreamRef streamRef,
             if ([pathWatcher ignoreEventsFromSubDirs]) {
                 for (NSString *path in [pathWatcher excludedPaths]) 
 				{
-					if (CFStringHasPrefix(eventPath, (__bridge CFStringRef)path)) {
+					if (CFStringHasPrefix(eventPathCf, (__bridge CFStringRef)path)) {
 						shouldIgnore = YES;
                         break;
 					}
@@ -357,46 +329,17 @@ static void _events_callback(ConstFSEventStreamRef streamRef,
         }
     
         if (!shouldIgnore) {
-			
 			// If present remove the path's trailing slash
-			eventPath = _strip_trailing_slash(eventPath);
+            eventPath = [eventPath stringByStandardizingPath];
             
-            SCEvent *event = [SCEvent eventWithEventId:(NSUInteger)eventIds[i] eventDate:[NSDate date] eventPath:(__bridge NSString *)eventPath eventFlags:(SCEventFlags)eventFlags[i]];
-			
-			CFRelease(eventPath);
-			
-            if ([[pathWatcher delegate] conformsToProtocol:@protocol(SCEventListenerProtocol)]) {
-                [[pathWatcher delegate] pathWatcher:pathWatcher eventOccurred:event];
-            }
-                
+            SCEvent *event = [SCEvent eventWithEventId:(NSUInteger)eventIds[i] eventDate:[NSDate date] eventPath:eventPath eventFlags:(SCEventFlags)eventFlags[i]];
+            [[pathWatcher delegate] pathWatcher:pathWatcher eventOccurred:event];
+            
             if (i == (numEvents - 1)) {
                 [pathWatcher setLastEvent:event];
             }
         }
     }
-}
-
-/**
- * If present, strips the trailing slash from the supplied string. Note, that the caler is
- * responsible for freeing the associate memory.
- *
- * @param string The string that is to be stripped
- *
- @ @return The resulting string
- */
-static CFStringRef _strip_trailing_slash(CFStringRef string)
-{
-	CFStringRef stripped = string;
-	
-	if (CFStringHasSuffix((CFStringRef)stripped, CFSTR("/"))) {
-		stripped = CFStringCreateWithSubstring(kCFAllocatorDefault, stripped, CFRangeMake(0, (CFStringGetLength(stripped) - 1)));				
-	}
-	
-#ifdef __OBJC_GC__
-	return (stripped) ? CFMakeCollectable(stripped) : string;
-#else
-	return (stripped) ? stripped : string;    
-#endif
 }
 
 @end


### PR DESCRIPTION
- Updated all property accessors to eliminate unnecessary ivars, specifications of getters/setters, etc.
- Fixed one or two memory management errors.
- Expanded list of event type flags, and wrapped into an NS_ENUM for nicer Swift interop.
